### PR TITLE
Add functionality to support multiple directories

### DIFF
--- a/src/LfmStorageRepository.php
+++ b/src/LfmStorageRepository.php
@@ -19,8 +19,20 @@ class LfmStorageRepository
 
     public function __call($function_name, $arguments)
     {
-        // TODO: check function exists
-        return $this->disk->$function_name($this->path, ...$arguments);
+        if ($function_name == 'directories') {
+            $directories = $this->disk->directories($this->path, ...$arguments);
+            $config = $this->helper->config('private_folder_name');
+
+            if(method_exists(app()->make($config), 'userAuthDirs')) {
+                return $this->getAuthDirectories($directories, app()->make($config)->userAuthDirs());
+            } else {
+                return $directories;
+            }
+            
+        } else {
+            // TODO: check function exists
+            return $this->disk->$function_name($this->path, ...$arguments);
+        }
     }
 
     public function rootPath()
@@ -61,5 +73,21 @@ class LfmStorageRepository
     {
         setlocale(LC_ALL, 'en_US.UTF-8');
         return pathinfo($this->path, PATHINFO_EXTENSION);
+    }
+
+    public function getAuthDirectories($directories, $auth_dirs)
+    {
+        $check = $directories;
+
+        if(count($auth_dirs)){
+            // remove unauthorized directories
+            foreach($check as $i => $directory) {
+                if(!in_array($directory, $auth_dirs)){
+                    unset($directories[$i]);
+                }
+            }
+        }
+
+        return $directories;
     }
 }


### PR DESCRIPTION
Summary of the change: 

      Added option to support multiple directories.

      You will be able to achieve that by publishing the LfmConfigHandler and defining a function with the name userAuthDirs()

      Inside that function, you can return an array with the user authorized working directories.

      Important note: In order to make this work you need to set the userField as '/' like in the example below.

      Example:

      class LfmConfigHandler
      {
          public function userField()
          {
              return '/';
          }

          public function userAuthDirs()
          {   
              // this will return for example ['files/department1', 'files/department4']
              return Auth::user()->departmentsDirNames();
          }
      }
